### PR TITLE
Fix async handling for ingredient information requests

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -83,6 +83,8 @@ const getIngredientInfo = async (ingredientId, ingredientName) => {
 
 const getIngredientsInfo = async (ingredientList) => {
   // need all spoonacularIds
+  // IDs were resolving as promises. Used Promise.all to handle multiple async calls
+  // This ensures that all IDs are fetched before continuing with the ingredient fetching
   let spoonIds = await Promise.all(ingredientList.map(async (ingredient) => {
     const id = await getSpoonacularId(ingredient);
     return {
@@ -96,6 +98,7 @@ const getIngredientsInfo = async (ingredientList) => {
       return cache[ingredient];
     }
 
+    // Needed an await here as well
     let ingredientData = id
       ? await getIngredientInfo(id, ingredient)
       : { name: ingredient, success: false };


### PR DESCRIPTION
This PR fixes an issue with fetching ingredient data using asynchronous code. The getSpoonacularId function was returning a Promise, but the code attempted to use it as if it were a resolved value. This caused errors when sending requests to the Spoonacular API, resulting in a success: false status for the ingredients. 

The changes ensure that the Promise from getSpoonacularId is properly resolved using await before continuing and making the API call. Additionally, Promise.all is used to handle multiple asynchronous calls. 

(I was receiving a failure when trying to retrieve ingredient data, and using console logging I found that the program was sending a Promise as the ingredient ID rather than the ingredient ID itself in the API call)